### PR TITLE
New Swedish translations

### DIFF
--- a/Bot/strings.ar-SA.resx
+++ b/Bot/strings.ar-SA.resx
@@ -2329,7 +2329,7 @@
         <value>Last 100 messages from channel: &lt;{0}&gt;</value>
     </data>
     <data name="moderation_report_perms" xml:space="preserve">
-        <value>I dont have send message permissions for the destination channel.</value>
+        <value>I don't have send message permissions for the destination channel.</value>
     </data>
     <data name="misc_afk_list" xml:space="preserve">
         <value>You can view a list of AFK users here: {0}/afk-list\nNote: Requires \"Manage Server\" access.</value>

--- a/Bot/strings.de-DE.resx
+++ b/Bot/strings.de-DE.resx
@@ -2332,7 +2332,7 @@ Wenn du nach einer Liste der Bot-Befehle suchst und wie sie funktionieren, klick
         <value>Last 100 messages from channel: &lt;{0}&gt;</value>
     </data>
     <data name="moderation_report_perms" xml:space="preserve">
-        <value>I dont have send message permissions for the destination channel.</value>
+        <value>I don't have send message permissions for the destination channel.</value>
     </data>
     <data name="misc_afk_list" xml:space="preserve">
         <value>You can view a list of AFK users here: {0}/afk-list\nNote: Requires \"Manage Server\" access.</value>

--- a/Bot/strings.el-GR.resx
+++ b/Bot/strings.el-GR.resx
@@ -2332,7 +2332,7 @@
         <value>Last 100 messages from channel: &lt;{0}&gt;</value>
     </data>
     <data name="moderation_report_perms" xml:space="preserve">
-        <value>I dont have send message permissions for the destination channel.</value>
+        <value>I don't have send message permissions for the destination channel.</value>
     </data>
     <data name="misc_afk_list" xml:space="preserve">
         <value>You can view a list of AFK users here: {0}/afk-list\nNote: Requires \"Manage Server\" access.</value>

--- a/Bot/strings.it-IT.resx
+++ b/Bot/strings.it-IT.resx
@@ -2334,7 +2334,7 @@ Se stai cercando un elenco di comandi del bot e come funzionano, clicca il link 
         <value>Last 100 messages from channel: &lt;{0}&gt;</value>
     </data>
     <data name="moderation_report_perms" xml:space="preserve">
-        <value>I dont have send message permissions for the destination channel.</value>
+        <value>I don't have send message permissions for the destination channel.</value>
     </data>
     <data name="misc_afk_list" xml:space="preserve">
         <value>You can view a list of AFK users here: {0}/afk-list\nNote: Requires \"Manage Server\" access.</value>

--- a/Bot/strings.ko-KR.resx
+++ b/Bot/strings.ko-KR.resx
@@ -2334,7 +2334,7 @@
         <value>Last 100 messages from channel: &lt;{0}&gt;</value>
     </data>
     <data name="moderation_report_perms" xml:space="preserve">
-        <value>I dont have send message permissions for the destination channel.</value>
+        <value>I don't have send message permissions for the destination channel.</value>
     </data>
     <data name="misc_afk_list" xml:space="preserve">
         <value>You can view a list of AFK users here: {0}/afk-list\nNote: Requires \"Manage Server\" access.</value>

--- a/Bot/strings.nl-NL.resx
+++ b/Bot/strings.nl-NL.resx
@@ -2329,7 +2329,7 @@ Note: A message will be sent upon completion.</value>
         <value>Last 100 messages from channel: &lt;{0}&gt;</value>
     </data>
     <data name="moderation_report_perms" xml:space="preserve">
-        <value>I dont have send message permissions for the destination channel.</value>
+        <value>I don't have send message permissions for the destination channel.</value>
     </data>
     <data name="misc_afk_list" xml:space="preserve">
         <value>You can view a list of AFK users here: {0}/afk-list\nNote: Requires \"Manage Server\" access.</value>

--- a/Bot/strings.resx
+++ b/Bot/strings.resx
@@ -2392,7 +2392,7 @@ If you are looking for a list of bot commands and how they work, click the `Bot 
       <value>User has been reported successfully.</value>
   </data>
   <data name="moderation_report_perms" xml:space="preserve">
-      <value>I dont have send message permissions for the destination channel.</value>
+      <value>I don't have send message permissions for the destination channel.</value>
   </data>
   <data name="misc_afk_list" xml:space="preserve">
       <value>You can view a list of AFK users here: {0}/afk-list\nNote: Requires \"Manage Server\" access.</value>

--- a/Bot/strings.ro-RO.resx
+++ b/Bot/strings.ro-RO.resx
@@ -2334,7 +2334,7 @@ Dacă sunteți în căutarea pentru o listă de comenzi bot și modul în care a
         <value>Last 100 messages from channel: &lt;{0}&gt;</value>
     </data>
     <data name="moderation_report_perms" xml:space="preserve">
-        <value>I dont have send message permissions for the destination channel.</value>
+        <value>I don't have send message permissions for the destination channel.</value>
     </data>
     <data name="misc_afk_list" xml:space="preserve">
         <value>You can view a list of AFK users here: {0}/afk-list\nNote: Requires \"Manage Server\" access.</value>

--- a/Bot/strings.sv-SE.resx
+++ b/Bot/strings.sv-SE.resx
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <xsd:schema id="root"
-    xmlns=""
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -2276,85 +2273,85 @@ Om du letar efter en lista över botkommandon och hur de fungerar, klicka på ar
   <data name="automod_check_stickers" xml:space="preserve">
     <value>Stickers</value>
   </data>
-    <data name="misc_no_content" xml:space="preserve">
-        <value>No Content</value>
-    </data>
-    <data name="misc_covid_help" xml:space="preserve">
-        <value>Help Stop COVID-19</value>
-    </data>
-    <data name="textman_invalid_output" xml:space="preserve">
-        <value>No valid output.</value>
-    </data>
-    <data name="info_premium" xml:space="preserve">
-        <value>:star: Like Cakey Bot? You can now donate for Premium:</value>
-    </data>
-    <data name="info_uptime" xml:space="preserve">
-        <value>Uptime: {0}</value>
-    </data>
-    <data name="info_open_image" xml:space="preserve">
-        <value>Open Image</value>
-    </data>
-    <data name="info_target_user" xml:space="preserve">
-        <value>Target User</value>
-    </data>
-    <data name="game_ttt_in_progress" xml:space="preserve">
-        <value>A game is already in progress, complete it before making a new game.</value>
-    </data>
-    <data name="game_ttt_title" xml:space="preserve">
-        <value>Tic Tac Toe</value>
-    </data>
-    <data name="game_player_1" xml:space="preserve">
-        <value>Player 1</value>
-    </data>
-    <data name="game_player_2" xml:space="preserve">
-        <value>Player 2</value>
-    </data>
-    <data name="game_current_move" xml:space="preserve">
-        <value>Current Move</value>
-    </data>
-    <data name="game_flip_again" xml:space="preserve">
-        <value>Flip Again</value>
-    </data>
-    <data name="moderation_report_yourself" xml:space="preserve">
-        <value>You can't report yourself!</value>
-    </data>
-    <data name="moderation_report_myself" xml:space="preserve">
-        <value>I can't report myself!</value>
-    </data>
-    <data name="moderation_report_channel_missing" xml:space="preserve">
-        <value>No report channel has been setup yet.</value>
-    </data>
-    <data name="moderation_report_channel_invalid" xml:space="preserve">
-        <value>The destination channel is invalid or no longer exists.</value>
-    </data>
-    <data name="moderation_report_reported_success" xml:space="preserve">
-        <value>User has been reported successfully.</value>
-    </data>
-    <data name="moderation_report_reported" xml:space="preserve">
-        <value>{0} reported {1} in &lt;#{2&gt;</value>
-    </data>
-    <data name="moderation_audit_messages_100" xml:space="preserve">
-        <value>Last 100 messages from channel: &lt;{0}&gt;</value>
-    </data>
-    <data name="moderation_report_perms" xml:space="preserve">
-        <value>I dont have send message permissions for the destination channel.</value>
-    </data>
-    <data name="misc_afk_list" xml:space="preserve">
-        <value>You can view a list of AFK users here: {0}/afk-list\nNote: Requires \"Manage Server\" access.</value>
-    </data>
-    <data name="button_invalid" xml:space="preserve">
-        <value>This button is no longer valid. :(</value>
-    </data>
-    <data name="game_ttt_expired" xml:space="preserve">
-        <value>This game has already expired. You can create a new game with `!tictactoe &lt;opt:user&gt;`.</value>
-    </data>
-    <data name="game_ttt_taken" xml:space="preserve">
-        <value>This spot is already taken.</value>
-    </data>
-    <data name="game_ttt_winner" xml:space="preserve">
-        <value>Winner</value>
-    </data>
-    <data name="game_ttt_wait_turn" xml:space="preserve">
-        <value>You must wait your turn to make a move!</value>
-    </data>
+  <data name="misc_no_content" xml:space="preserve">
+    <value>Saknar innehåll</value>
+  </data>
+  <data name="misc_covid_help" xml:space="preserve">
+    <value>Hjälp till att stoppa COVID-19</value>
+  </data>
+  <data name="textman_invalid_output" xml:space="preserve">
+    <value>Ogiltig inmatning.</value>
+  </data>
+  <data name="info_premium" xml:space="preserve">
+    <value>:star: Gillar du Cakey Bot? Du kan nu donera för Premium:</value>
+  </data>
+  <data name="info_uptime" xml:space="preserve">
+    <value>Drifttid: {0}</value>
+  </data>
+  <data name="info_open_image" xml:space="preserve">
+    <value>Öppna bild</value>
+  </data>
+  <data name="info_target_user" xml:space="preserve">
+    <value>Berörd användare</value>
+  </data>
+  <data name="game_ttt_in_progress" xml:space="preserve">
+    <value>Ett spel pågår redan, avsluta det innan du skapar ett nytt.</value>
+  </data>
+  <data name="game_ttt_title" xml:space="preserve">
+    <value>Tre-i-rad</value>
+  </data>
+  <data name="game_player_1" xml:space="preserve">
+    <value>Spelare 1</value>
+  </data>
+  <data name="game_player_2" xml:space="preserve">
+    <value>Spelare 2</value>
+  </data>
+  <data name="game_current_move" xml:space="preserve">
+    <value>Nuvarande drag</value>
+  </data>
+  <data name="game_flip_again" xml:space="preserve">
+    <value>Vänd igen</value>
+  </data>
+  <data name="moderation_report_yourself" xml:space="preserve">
+    <value>Du kan inte anmäla dig själv!</value>
+  </data>
+  <data name="moderation_report_myself" xml:space="preserve">
+    <value>Jag kan inte anmäla mig själv!</value>
+  </data>
+  <data name="moderation_report_channel_missing" xml:space="preserve">
+    <value>Ingen anmälningskanal har ställts in ännu.</value>
+  </data>
+  <data name="moderation_report_channel_invalid" xml:space="preserve">
+    <value>Destinationskanalen är ogiltig eller finns inte längre.</value>
+  </data>
+  <data name="moderation_report_reported_success" xml:space="preserve">
+    <value>Användare har framgångsrikt anmälts.</value>
+  </data>
+  <data name="moderation_report_reported" xml:space="preserve">
+    <value>{0} anmälde {1} i &lt;#{2&gt;</value>
+  </data>
+  <data name="moderation_audit_messages_100" xml:space="preserve">
+    <value>Senaste 100 meddelanden från kanal: &lt;{0}&gt;</value>
+  </data>
+  <data name="moderation_report_perms" xml:space="preserve">
+    <value>Jag har inte behörighet att skicka meddelanden i destinationskanalen.</value>
+  </data>
+  <data name="misc_afk_list" xml:space="preserve">
+    <value>Du kan se en lista av AFK-användare här: {0}/afk-list\nNotera: Kräver \"Hantera server\"-behörighet.</value>
+  </data>
+  <data name="button_invalid" xml:space="preserve">
+    <value>Denna knapp är inte längre giltig. :(</value>
+  </data>
+  <data name="game_ttt_expired" xml:space="preserve">
+    <value>Detta spel har redan utgått. Du kan starta ett nytt spel via `!tictactoe &lt;opt:user&gt;`.</value>
+  </data>
+  <data name="game_ttt_taken" xml:space="preserve">
+    <value>Denna plats är redan upptagen.</value>
+  </data>
+  <data name="game_ttt_winner" xml:space="preserve">
+    <value>Vinnare</value>
+  </data>
+  <data name="game_ttt_wait_turn" xml:space="preserve">
+    <value>Du måste vänta på din tur innan du gör ett drag!</value>
+  </data>
 </root>

--- a/Bot/strings.tr-TR.resx
+++ b/Bot/strings.tr-TR.resx
@@ -2331,7 +2331,7 @@ Eğer komutların listesini veya nasıl çalıştıklarını arıyorsan, aşağ�
         <value>Last 100 messages from channel: &lt;{0}&gt;</value>
     </data>
     <data name="moderation_report_perms" xml:space="preserve">
-        <value>I dont have send message permissions for the destination channel.</value>
+        <value>I don't have send message permissions for the destination channel.</value>
     </data>
     <data name="misc_afk_list" xml:space="preserve">
         <value>You can view a list of AFK users here: {0}/afk-list\nNote: Requires \"Manage Server\" access.</value>


### PR DESCRIPTION
Also fixed a typo in the source string for `moderation_report_perms` across all languages (dont => don't).